### PR TITLE
Remove token argument from gh-pages deploy step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,4 +39,4 @@ jobs:
       - name: Deploy to GitHub Pages
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx gh-pages -d dist -t $GH_TOKEN
+        run: npx gh-pages -d dist


### PR DESCRIPTION
The deploy step in the GitHub Actions workflow no longer passes the -t $GH_TOKEN argument to the gh-pages command, relying on default authentication via the environment variable.