### PR TITLE
Update AI Comparison Showcase image import

### DIFF
--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -20,7 +20,7 @@ import bigBangGalleryImg from '../images/bigbanggallery.webp';
 import pythonProjectsImg from '../images/pythonprojects.webp';
 import versionTimeTravelImg from '../images/versiontimetravel.webp';
 import newsperspectiveImg from '../images/newsperspective.webp';
-import aiComparisonShowcaseImg from '../images/aicomparisonshowcase.webp';
+import aiComparisonShowcaseImg from '../images/aicomparisonshowcase3.webp';
 
 interface Project {
   id: string;


### PR DESCRIPTION
Changed the import for aiComparisonShowcaseImg to use 'aicomparisonshowcase3.webp' instead of 'aicomparisonshowcase.webp'.

Rookie error.. At least can fully test the new GitHub pages deployment pipeline, now it is working correctly 😊

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the image displayed for the AI comparison showcase on the projects page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->