### PR TITLE
Complete migration to root domain - remove all /ThomasJButler references

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -6,7 +6,7 @@
     <title>Blog - Thomas J Butler | Redirecting...</title>
     
     <!-- Immediate redirect to React app blog -->
-    <meta http-equiv="refresh" content="0; url=/ThomasJButler/react.html#blog">
+    <meta http-equiv="refresh" content="0; url=/react.html#blog">
     
     <!-- SEO Meta Tags -->
     <meta name="description" content="Read thought leadership articles by Thomas J Butler on AI, development, and human-centered technology.">
@@ -16,7 +16,7 @@
     <!-- Open Graph -->
     <meta property="og:title" content="Blog - Thomas J Butler">
     <meta property="og:description" content="Thought leadership on AI, development, and human-centered technology">
-    <meta property="og:url" content="https://thomasjbutler.github.io/ThomasJButler/blog.html">
+    <meta property="og:url" content="https://thomasjbutler.github.io/blog.html">
     
     <style>
         body {
@@ -56,14 +56,14 @@
                 return;
             }
             // Redirect to React app blog route
-            window.location.replace('/ThomasJButler/react.html#blog');
+            window.location.replace('/react.html#blog');
         };
     </script>
 </head>
 <body>
     <div class="redirect-message">
         <h1 class="matrix-text">Redirecting to Blog...</h1>
-        <p>If you are not redirected automatically, <a href="/ThomasJButler/react.html#blog">click here</a>.</p>
+        <p>If you are not redirected automatically, <a href="/react.html#blog">click here</a>.</p>
     </div>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Thomas J Butler - Portfolio | Full-Stack Developer | Liverpool</title>
     
     <!-- Immediate redirect to React app -->
-    <meta http-equiv="refresh" content="0; url=/ThomasJButler/react.html">
+    <meta http-equiv="refresh" content="0; url=/react.html">
     
     <!-- Basic Meta Tags -->
     <meta name="description" content="Thomas J Butler - Full-Stack Developer specializing in React, TypeScript, AI integration, and neurodiversity applications. Liverpool-based tech innovator with expertise in modern web development.">
@@ -17,22 +17,22 @@
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://thomasjbutler.github.io/ThomasJButler/">
+    <meta property="og:url" content="https://thomasjbutler.github.io/">
     <meta property="og:title" content="Thomas J Butler - Full-Stack Developer Portfolio">
     <meta property="og:description" content="Explore the portfolio of Thomas J Butler, a Liverpool-based full-stack developer specializing in React, TypeScript, and AI integration.">
-    <meta property="og:image" content="https://thomasjbutler.github.io/ThomasJButler/logo.svg">
+    <meta property="og:image" content="https://thomasjbutler.github.io/logo.svg">
     <meta property="og:site_name" content="Thomas J Butler Portfolio">
     <meta property="og:locale" content="en_GB">
     
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:url" content="https://thomasjbutler.github.io/ThomasJButler/">
+    <meta name="twitter:url" content="https://thomasjbutler.github.io/">
     <meta name="twitter:title" content="Thomas J Butler - Full-Stack Developer Portfolio">
     <meta name="twitter:description" content="Liverpool-based full-stack developer specializing in React, TypeScript, and AI integration. View my projects and expertise.">
-    <meta name="twitter:image" content="https://thomasjbutler.github.io/ThomasJButler/logo.svg">
+    <meta name="twitter:image" content="https://thomasjbutler.github.io/logo.svg">
     
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://thomasjbutler.github.io/ThomasJButler/">
+    <link rel="canonical" href="https://thomasjbutler.github.io/">
     
     <!-- Theme Color -->
     <meta name="theme-color" content="#00FF00">
@@ -44,11 +44,11 @@
       "@type": "Person",
       "name": "Thomas J Butler",
       "jobTitle": "Full-Stack Developer",
-      "url": "https://thomasjbutler.github.io/ThomasJButler",
-      "image": "https://thomasjbutler.github.io/ThomasJButler/logo.svg",
+      "url": "https://thomasjbutler.github.io",
+      "image": "https://thomasjbutler.github.io/logo.svg",
       "logo": {
         "@type": "ImageObject",
-        "url": "https://thomasjbutler.github.io/ThomasJButler/logo.svg"
+        "url": "https://thomasjbutler.github.io/logo.svg"
       },
       "sameAs": [
         "https://github.com/ThomasJButler",
@@ -169,14 +169,14 @@
         // JavaScript redirect to React app
         window.onload = function() {
             // Redirect to React app homepage
-            window.location.replace('/ThomasJButler/react.html');
+            window.location.replace('/react.html');
         };
         
         // Fallback redirect after 3 seconds
         setTimeout(function() {
-            if (window.location.pathname === '/ThomasJButler/' || 
-                window.location.pathname === '/ThomasJButler/index.html') {
-                window.location.replace('/ThomasJButler/react.html');
+            if (window.location.pathname === '/' ||
+                window.location.pathname === '/index.html') {
+                window.location.replace('/react.html');
             }
         }, 3000);
     </script>
@@ -189,7 +189,7 @@
         <div class="loading-bar">
             <div class="loading-progress"></div>
         </div>
-        <p>If you are not redirected automatically, <a href="/ThomasJButler/react.html">click here</a>.</p>
+        <p>If you are not redirected automatically, <a href="/react.html">click here</a>.</p>
     </div>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "name": "thomasjbutler",
   "description": "Hi there! I'm Tom, an aspiring full-stack web developer passionate about exploring the depths of technology. \r My journey spans from web development to exciting areas like networking, database analysis, indie game development, and creating engaging creations with AI. \r I aim to blend insatiable curiosity with practical skills, delving into everything from creating engaging websites to understanding AI principles and game design. \r Join me as I explore the nuts and bolts of technology, hoping to push the boundaries of whats possible in web development and beyond.",
   "version": "3.5.0",
-  "homepage": "https://thomasjbutler.github.io/ThomasJButler",
+  "homepage": "https://thomasjbutler.github.io",
   "main": "index.js",
   "scripts": {
     "dev": "vite",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,15 +2,15 @@
   "name": "Thomas J Butler - Portfolio",
   "short_name": "TJB Portfolio",
   "description": "Liverpool-based Full Stack Developer specializing in AI integration",
-  "start_url": "/ThomasJButler/",
-  "scope": "/ThomasJButler/",
+  "start_url": "/",
+  "scope": "/",
   "display": "standalone",
   "background_color": "#000000",
   "theme_color": "#00FF00",
   "orientation": "portrait-primary",
   "icons": [
     {
-      "src": "/ThomasJButler/logo.svg",
+      "src": "/logo.svg",
       "sizes": "any",
       "type": "image/svg+xml",
       "purpose": "any maskable"

--- a/react.html
+++ b/react.html
@@ -19,12 +19,12 @@
     <link rel="icon" type="image/svg+xml" href="./logo.svg">
 
     <!-- Open Graph Logo -->
-    <meta property="og:image" content="https://thomasjbutler.github.io/ThomasJButler/logo.svg">
+    <meta property="og:image" content="https://thomasjbutler.github.io/logo.svg">
     <meta property="og:image:alt" content="Thomas J Butler Logo">
 
     <!-- Twitter Card Logo -->
     <meta name="twitter:card" content="summary">
-    <meta name="twitter:image" content="https://thomasjbutler.github.io/ThomasJButler/logo.svg">
+    <meta name="twitter:image" content="https://thomasjbutler.github.io/logo.svg">
     <meta name="twitter:image:alt" content="Thomas J Butler Logo">
 
     <!-- PWA Manifest -->

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -99,7 +99,7 @@ export const App: React.FC = () => {
     <ThemeProvider>
       {/* Global components outside Router to avoid context issues */}
       <BackToTop threshold={300} showText={true} enableScanLine={true} />
-      <Router basename="/ThomasJButler">
+      <Router>
         <ReactHtmlRedirect />
         <Routes>
           <Route path="/" element={<Layout />}>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -125,7 +125,7 @@ export const Header: React.FC = () => {
       <div className={styles.container}>
         <Link to="/" className={styles.headerTitle}>
           <img
-            src="/ThomasJButler/logo.svg"
+            src="/logo.svg"
             alt="Thomas J Butler Logo"
             className={styles.headerLogo}
           />

--- a/src/utils/blogLoader.ts
+++ b/src/utils/blogLoader.ts
@@ -130,8 +130,8 @@ function getBasePath(): string {
   if (import.meta.env.DEV) {
     return '';
   }
-  // In production, use GitHub Pages subdirectory
-  return '/ThomasJButler';
+  // In production, use root path
+  return '';
 }
 
 /**

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -6,7 +6,7 @@ import { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync } from '
 
 export default defineConfig({
   root: '.',
-  base: '/ThomasJButler/',
+  base: '/',
   build: {
     outDir: 'dist',
     rollupOptions: {
@@ -37,7 +37,7 @@ export default defineConfig({
     {
       name: 'serve-blog-files',
       configureServer(server) {
-        // Serve markdown files - handle both /src/content/blog and /ThomasJButler/src/content/blog paths
+        // Serve markdown files from /src/content/blog path
         server.middlewares.use((req, res, next) => {
           // Check if this is a request for a blog markdown file
           const url = req.url;
@@ -45,8 +45,8 @@ export default defineConfig({
 
           if (url.startsWith('/src/content/blog/')) {
             blogPath = url.replace('/src/content/blog/', '');
-          } else if (url.startsWith('/ThomasJButler/src/content/blog/')) {
-            blogPath = url.replace('/ThomasJButler/src/content/blog/', '');
+          } else if (url.startsWith('/src/content/blog/')) {
+            blogPath = url.replace('/src/content/blog/', '');
           }
 
           if (blogPath && blogPath.endsWith('.md')) {
@@ -70,19 +70,19 @@ export default defineConfig({
         });
 
         // Redirect blog article routes to React app with hash
-        server.middlewares.use('/ThomasJButler/blog/', (req, res, next) => {
+        server.middlewares.use('/blog/', (req, res, next) => {
           // Extract the blog slug from the URL
           const path = req.url;
           const slug = path.split('/').pop();
           
           if (slug && slug !== 'blog') {
             // Redirect to react.html with hash routing
-            const redirectUrl = `/ThomasJButler/react.html#/blog/${slug}`;
+            const redirectUrl = `/react.html#/blog/${slug}`;
             res.writeHead(302, { Location: redirectUrl });
             res.end();
           } else {
             // For /blog route, redirect to blog list
-            const redirectUrl = `/ThomasJButler/react.html#/blog`;
+            const redirectUrl = `/react.html#/blog`;
             res.writeHead(302, { Location: redirectUrl });
             res.end();
           }
@@ -119,7 +119,7 @@ export default defineConfig({
   ],
   server: {
     port: 3000,
-    open: '/ThomasJButler/react.html', // Open directly to correct URL to avoid base path warning
+    open: '/react.html', // Open directly to correct URL to avoid base path warning
     watch: {
       usePolling: true
     }


### PR DESCRIPTION
BREAKING CHANGE: Site now deploys to https://thomasjbutler.github.io/ instead of /ThomasJButler subdirectory! 🤗

Changes made:
- Update Router configuration: Remove basename="/ThomasJButler"
- Update Vite config: Set base path to "/" and fix all middleware paths
- Update package.json: Change homepage to root domain
- Fix all HTML files: Update redirects and meta tags
- Update manifest.json: Fix start_url, scope, and icon paths
- Fix component paths: Update logo references in Header
- Fix blog loader: Remove production subdirectory path
- Add Contact Me badge to README

This required the GitHub repository to be renamed to thomasjbutler.github.io, and I made a new special repo at 'ThomasJButler' to add a shortened README.md. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the site's URL structure to use root paths instead of subdirectories. This simplifies URLs across the entire application, including blog content, static assets, and internal redirects, resulting in cleaner site navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->