### PR TITLE
Morpheus goes local, two new projects, and stop the CRT layers dimming the text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,174 +1,130 @@
-<div align="center">
+# thomasjbutler.github.io
 
-## About Me
+My personal site. Matrix-themed, prerendered, and built from scratch because I wanted to.
 
-My passion is to build human orientated applications that feel natural and joyful to use, and empower humanity by harnessing the power of AI, by saving time and energy on day to day tasks.
+**[thomasjbutler.github.io](https://thomasjbutler.github.io)** · the paid work lives at **[thomasjbutler.me](https://thomasjbutler.me)**
 
-I'm currently focused on creating AI integrated systems, building ethical AI models, and Next.js/React web applications as a secure front-end.
+React 19, TypeScript, Vite 7, Tailwind 4. Cursor-reactive Matrix rain on a canvas, CRT scanlines, a terminal-style command palette, and a light theme for people who would rather not.
 
-[![Commercial Portfolio](https://img.shields.io/badge/Commercial%20Portfolio-View-006400?style=for-the-badge&logo=matrix&logoColor=white)](https://thomasjbutler.me)
-[![Personal Portfolio](https://img.shields.io/badge/Personal%20Portfolio-View-006400?style=for-the-badge&logo=matrix&logoColor=white)](https://thomasjbutler.github.io/ThomasJButler/)
+---
 
-<img width="1337" height="714" alt="v3 6" src="https://github.com/user-attachments/assets/7dec964a-2649-409d-97eb-468349f600a1" />
+## What's in here
 
-## Featured Projects
+**Projects.** Twenty of them, filterable, from an on-device iOS app and a local RAG pipeline down to the CSS demos I built while learning CSS. The tags say which is which, on purpose: the arc from one to the other is the point.
 
-- **SQL-Ball** – RAG-powered NL-to-SQL using a custom collated dataset of European football results. [GitHub →](https://github.com/ThomasJButler/SQL-Ball)
-- **AgenticAICoursePortfolio** – Portfolio of web apps from the Generative AI & Agents Bootcamp. [GitHub →](https://github.com/ThomasJButler/AgenticAICoursePortfolio)
-- **The Matrix Arcade** – Collection of custom-built games in the style of “The Matrix.” [GitHub →](https://github.com/ThomasJButler/The-Matrix-Arcade)
+**A case study.** One build taken apart properly: the problem, the architecture, and what I'd do differently.
 
-## My Tech Stacks
+**A dev journey.** Every month since I started, from the first line of code to now, by way of the DWP and an agency apprenticeship.
 
-<table align="center">
-<tr>
-<td align="center" width="96">
-<img src="https://skillicons.dev/icons?i=react" width="48" height="48" alt="React" />
-<br>React
-</td>
-<td align="center" width="96">
-<img src="https://skillicons.dev/icons?i=typescript" width="48" height="48" alt="TypeScript" />
-<br>TypeScript
-</td>
-<td align="center" width="96">
-<img src="https://skillicons.dev/icons?i=vite" width="48" height="48" alt="Vite" />
-<br>Vite
-</td>
-<td align="center" width="96">
-<img src="https://skillicons.dev/icons?i=python" width="48" height="48" alt="Python" />
-<br>Python
-</td>
-<td align="center" width="96">
-<img src="https://skillicons.dev/icons?i=django" width="48" height="48" alt="Django" />
-<br>Django
-</td>
-<td align="center" width="96">
-<img src="https://skillicons.dev/icons?i=nodejs" width="48" height="48" alt="Node.js" />
-<br>Node.js
-</td>
-<td align="center" width="96">
-<img src="https://skillicons.dev/icons?i=dotnet" width="48" height="48" alt=".NET" />
-<br>.NET
-</td>
-<td align="center" width="96">
-<img src="https://skillicons.dev/icons?i=cs" width="48" height="48" alt="C#" />
-<br>C#
-</td>
-</tr>
-<tr>
-<td align="center" width="96">
-<img src="https://skillicons.dev/icons?i=postgresql" width="48" height="48" alt="PostgreSQL" />
-<br>PostgreSQL
-</td>
-<td align="center" width="96">
-<img src="https://skillicons.dev/icons?i=mongodb" width="48" height="48" alt="MongoDB" />
-<br>MongoDB
-</td>
-<td align="center" width="96">
-<img src="https://skillicons.dev/icons?i=supabase" width="48" height="48" alt="Supabase" />
-<br>Supabase
-</td>
-<td align="center" width="96">
-<img src="https://skillicons.dev/icons?i=docker" width="48" height="48" alt="Docker" />
-<br>Docker
-</td>
-<td align="center" width="96">
-<img src="https://skillicons.dev/icons?i=aws" width="48" height="48" alt="AWS" />
-<br>AWS
-</td>
-<td align="center" width="96">
-<img src="https://skillicons.dev/icons?i=azure" width="48" height="48" alt="Azure" />
-<br>Azure
-</td>
-<td align="center" width="96">
-<img src="https://skillicons.dev/icons?i=vercel" width="48" height="48" alt="Vercel" />
-<br>Vercel
-</td>
-<td align="center" width="96">
-<img src="https://skillicons.dev/icons?i=tailwind" width="48" height="48" alt="Tailwind" />
-<br>Tailwind
-</td>
-</tr>
-<tr>
-<td align="center" width="96">
-<img src="https://skillicons.dev/icons?i=tensorflow" width="48" height="48" alt="TensorFlow" />
-<br>TensorFlow
-</td>
-<td align="center" width="96">
-<img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/scikitlearn/scikitlearn-original.svg" width="48" height="48" alt="Scikit-learn" />
-<br>Scikit-learn
-</td>
-<td align="center" width="96">
-<img src="https://www.svgrepo.com/show/306500/openai.svg" width="48" height="48" alt="OpenAI" />
-<br>OpenAI
-</td>
-<td align="center" width="96">
-<img src="https://cdn.worldvectorlogo.com/logos/langchain.svg" width="48" height="48" alt="LangChain" />
-<br>LangChain
-</td>
-<td align="center" width="96">
-<img src="https://skillicons.dev/icons?i=css" width="48" height="48" alt="CSS3" />
-<br>CSS3
-</td>
-<td align="center" width="96">
-<img src="https://skillicons.dev/icons?i=html" width="48" height="48" alt="HTML5" />
-<br>HTML5
-</td>
-<td align="center" width="96">
-<img src="https://skillicons.dev/icons?i=git" width="48" height="48" alt="Git" />
-<br>Git
-</td>
-<td align="center" width="96">
-<img src="https://skillicons.dev/icons?i=vscode" width="48" height="48" alt="VS Code" />
-<br>VS Code
-</td>
-</tr>
-</table>
+**Version TimeTravel.** [Nine previous versions of this site](https://thomasjbutler.github.io/version-timetravel/), every one still running as it originally shipped. It's the one thing a CV can't do.
 
-## Credentials & Specialisations
+---
 
-### Qualifications
-- **AWS Qualified** | **Azure Qualified** | **Cisco Qualified** | **HubSpot Qualified**
-- Level 4 Software Developer Apprenticeship, studied 2023-24
-- City & Guilds Level 2 ICT Systems Support (May 2025)
-- Machine Learning: Mastering Generative AI & Agents (September 2025)
+## Architecture
 
-### Areas of Focus
-- **AI & ML** → Custom models, LLM training, prompt engineering, performance testing
-- **Automation** → n8n workflows, API integrations, MCP creation, custom AI models
-- **CSS** → GSAP animations, 3D transforms, Matrix effects
-- **Full-Stack** → End-to-end application development  
+### It's prerendered, not an SPA
 
-## GitHub Stats
+Every route is rendered to real HTML at build time. This isn't an optimisation, it's the difference between existing and not existing for a whole class of reader: **GPTBot, ClaudeBot and PerplexityBot fetch HTML and don't execute JavaScript.** Before this, `/about` shipped zero characters of body text.
 
-<div align="center">
+- `src/entry-server.tsx` renders each route with `prerenderToNodeStream`.
+- `scripts/routes.mjs` is the single source of truth for routes, titles and descriptions.
+- `scripts/prerender.mjs` injects markup, per-route meta and JSON-LD, and **fails the build if any route emits under 600 characters of text.** A component that silently renders nothing on the server is invisible otherwise.
+- `src/main.tsx` **hydrates** rather than mounting fresh, so the prerendered DOM survives.
 
-![Thomas's GitHub stats](https://github-readme-stats.vercel.app/api?username=ThomasJButler&show_icons=true&theme=chartreuse-dark&border_color=00FF00&bg_color=0D1117&title_color=00FF00&icon_color=00FF00&text_color=FFFFFF)
+### The effects layer
 
-![Activity Graph](https://github-readme-activity-graph.vercel.app/graph?username=ThomasJButler&theme=react-dark&bg_color=0D1117&color=00FF00&line=00FF00&point=FFFFFF&area_color=00FF00&area=true&hide_border=true)
+`src/lib/fx/rain-engine.ts` is the Matrix rain as a plain class, so its maths is unit-tested without a canvas. The performance constraints in it are load-bearing rather than fussy: the first version dropped the page to 20fps. It renders at DPR 1, draws at 30fps with time-scaled movement, bounds each stream to 16-34 glyphs, and batches the column heads into a single pass.
 
-</div>
+The pointer "morph" (glyphs parting around the cursor, click ripples) is gated on dark theme + rain on + a fine pointer. When that gate is shut there are no pointer listeners on the page at all.
 
-<div align="center">
-  
-## Get in Touch
+Everything cinematic answers to one switch, `useFx().motionOk`, which folds the OS reduced-motion preference together with an in-page toggle. WCAG 2.2.2 needs that in-page control for auto-playing motion; `prefers-reduced-motion` alone doesn't satisfy it.
 
-</div>
+### Styling
 
-<div align="center">
-  
-[![LinkedIn](https://img.shields.io/badge/LinkedIn-Connect-0077B5?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/thomasbutleruk/)
-[![CodePen](https://img.shields.io/badge/CodePen-Follow-1e1e1e?style=for-the-badge&logo=codepen&logoColor=white)](https://codepen.io/thomasjbutler)
-[![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-Support-FFB000?style=for-the-badge&logo=buy-me-a-coffee&logoColor=black)](https://buymeacoffee.com/ojrwoqkgmv)
+One file, `src/app.css`. Tailwind 4, CSS-first, so there's no `tailwind.config`. Theme tokens are custom properties and light/dark is a `.dark` class on `<html>`.
 
-</div>
+---
 
-<div align="center">
+## Project structure
 
-**Email:** [dev@thomasjbutler.me](mailto:dev@thomasjbutler.me) |-------|
-**Resume:** [Download Resume (PDF)](https://cvgenius.com/uk/cv-link/ca1e2690-125c-4422-804d-b68c1935f598/449d6614-8209-4741-bd30-2fc12fe4f8e8)
+```
+├── index.html              the app shell, plus the pre-paint theme script
+├── scripts/
+│   ├── routes.mjs          every route, title and description. Also a runtime import
+│   ├── prerender.mjs       renders each route to HTML, enforces the 600-char floor
+│   └── structured-data.mjs per-route JSON-LD
+├── src/
+│   ├── app.css             all of it
+│   ├── entry-server.tsx    the server render entry
+│   ├── main.tsx            hydrates #root
+│   ├── components/
+│   │   ├── fx/             decode-in text, reveal-on-scroll
+│   │   ├── home/           hero, terminal console, proof section
+│   │   ├── layout/         header, footer, page transition
+│   │   ├── system/         command palette, atmosphere, toaster, easter eggs
+│   │   └── ui/             shadcn components, on Base UI
+│   ├── contexts/           theme, accent, effects
+│   ├── lib/
+│   │   ├── content.ts      the copy. Import it, don't retype it
+│   │   ├── projects.ts     the project data
+│   │   ├── timeline.ts     the dev journey
+│   │   ├── assets.ts       Cloudinary URL map
+│   │   └── fx/             rain engine, decode, easing
+│   └── pages/              one per route
+└── e2e/                    Playwright screenshots and page checks
+```
 
-</div>
+---
 
-<div align="center">
-  <img src="https://capsule-render.vercel.app/api?type=waving&color=00FF00&height=100&section=footer" width="100%" />
-</div>
+## Running it
+
+Node 22.
+
+```bash
+npm install
+npm run dev          # localhost:3000
+```
+
+| Command | What it does |
+|---|---|
+| `npm run dev` | Dev server on port 3000 |
+| `npm run build` | Client build, then an SSR build, then the prerender |
+| `npm run preview` | Serves `dist/`. The `--outDir dist` is load-bearing |
+| `npm run type-check` | `tsc --noEmit` |
+| `npm run lint` | ESLint over `src` |
+| `npx vitest run` | Unit and component tests, once |
+| `npm run test:e2e` | Playwright |
+| `npm run deploy` | Build and publish to GitHub Pages |
+
+---
+
+## Quality
+
+Lighthouse, desktop, against a production build. Measured 27 August 2026, not aspirational:
+
+| | Score |
+|---|---|
+| Accessibility | **100** |
+| Best Practices | **100** |
+| SEO | **100** |
+| Agentic Browsing | **97** |
+| Cumulative Layout Shift | **0.00** |
+
+That CLS number was 0.144 once. Getting it to zero took three things that all look like dead weight to anyone tidying up: a full-screen loader reservation, a hidden per-character sizer inside the decode-in text, and metric-matched fallback `@font-face` blocks (Orbitron is 18.9% wider than Arial, so every heading re-wrapped on font load). They're all commented where they live.
+
+The test suite is 117 unit and component tests across 17 files, plus Playwright for screenshots and page checks.
+
+---
+
+## Licence
+
+MIT.
+
+---
+
+## Contact
+
+**Tom Butler** · Leeds, Yorkshire
+Looking for full-time work: junior for general software, any non-senior level for AI.
+
+[dev@thomasjbutler.me](mailto:dev@thomasjbutler.me) · [LinkedIn](https://www.linkedin.com/in/thomasbutleruk/) · [GitHub](https://github.com/ThomasJButler) · [Commercial work](https://thomasjbutler.me)

--- a/README.md
+++ b/README.md
@@ -100,15 +100,17 @@ npm run dev          # localhost:3000
 
 ## Quality
 
-Lighthouse, desktop, against a production build. Measured 27 August 2026, not aspirational:
+Lighthouse, desktop, against a production build, on `/` and `/projects`. Measured
+27 August 2026, not aspirational:
 
-| | Score |
-|---|---|
-| Accessibility | **100** |
-| Best Practices | **100** |
-| SEO | **100** |
-| Agentic Browsing | **97** |
-| Cumulative Layout Shift | **0.00** |
+| | `/` | `/projects` |
+|---|---|---|
+| Accessibility | **100** | **100** |
+| Best Practices | **100** | **100** |
+| SEO | **100** | **100** |
+| Agentic Browsing | 97 | **100** |
+
+Cumulative Layout Shift is **0.00**, from a separate trace.
 
 That CLS number was 0.144 once. Getting it to zero took three things that all look like dead weight to anyone tidying up: a full-screen loader reservation, a hidden per-character sizer inside the decode-in text, and metric-matched fallback `@font-face` blocks (Orbitron is 18.9% wider than Arial, so every heading re-wrapped on font load). They're all commented where they live.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ React 19, TypeScript, Vite 7, Tailwind 4. Cursor-reactive Matrix rain on a canva
 
 **A dev journey.** Every month since I started, from the first line of code to now, by way of the DWP and an agency apprenticeship.
 
-**Version TimeTravel.** [Nine previous versions of this site](https://thomasjbutler.github.io/version-timetravel/), every one still running as it originally shipped. It's the one thing a CV can't do.
+**Version TimeTravel.** [Every previous version of this site](https://thomasjbutler.github.io/version-timetravel/), still running as it originally shipped. It's the one thing a CV can't do.
 
 ---
 
@@ -120,7 +120,8 @@ The test suite is 117 unit and component tests across 17 files, plus Playwright 
 
 ## Licence
 
-MIT.
+`package.json` declares ISC. There's no LICENSE file in the repo yet, so treat that as
+the intent rather than the paperwork.
 
 ---
 

--- a/e2e/screenshots.spec.ts
+++ b/e2e/screenshots.spec.ts
@@ -56,8 +56,8 @@ for (const theme of themes) {
 test.describe('page content checks', () => {
   test('home page has hero and proof section', async ({ page }) => {
     await page.goto('/', { waitUntil: 'domcontentloaded' });
-    await expect(page.locator('text=Hey, I\'m Tom')).toBeVisible();
-    await expect(page.locator('text=software developer · leeds, yorkshire')).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1 })).toContainText("Hey, I'm Tom");
+    await expect(page.locator('text=software developer · leeds, yorkshire').first()).toBeVisible();
     // Proof section: the case study card and the "recently" card
     await autoScroll(page);
     await page.waitForTimeout(1000);
@@ -78,23 +78,31 @@ test.describe('page content checks', () => {
   });
 
   test('projects page filtering works', async ({ page }) => {
-    await page.goto('/projects', { waitUntil: 'domcontentloaded' });
-    await page.waitForTimeout(1000);
+    // networkidle, not domcontentloaded: this route is lazy-loaded, so the prerendered
+    // markup is on screen and NOT interactive for a while. Clicking a tab in that window
+    // does nothing, the grid stays on "All", and the count assertion below fails with a
+    // number that looks like a filtering bug rather than a timing one.
+    await page.goto('/projects', { waitUntil: 'networkidle' });
 
-    // Click the "AI & ML" tab
-    await page.locator('[data-slot="tabs-trigger"]', { hasText: 'AI & ML' }).click();
-    await page.waitForTimeout(500);
+    // Scroll it in and let the whileInView reveals finish before clicking. The tab bar
+    // sits below the fold, and the sections above it animate in as you arrive, so a click
+    // fired mid-reveal lands where the tab used to be. The filter itself is fine.
+    const aiTab = page.locator('[data-slot="tabs-trigger"]', { hasText: 'AI & ML' });
+    await aiTab.scrollIntoViewIfNeeded();
+    await page.waitForTimeout(1200);
+    await aiTab.click();
+    // Prove the click landed before counting anything.
+    await expect(aiTab).toHaveAttribute('aria-selected', 'true');
 
-    // All visible cards should be AI projects
+    // The featured strip only renders on "All", so a filtered page is grid cards only.
     const cards = page.locator('[data-slot="card"]');
-    const count = await cards.count();
-    expect(count).toBeGreaterThan(0);
-    expect(count).toBeLessThan(15); // Should be filtered down
+    await expect.poll(() => cards.count()).toBeLessThan(15);
+    expect(await cards.count()).toBeGreaterThan(0);
 
-    // Click "All" tab to reset
-    await page.locator('[data-slot="tabs-trigger"]', { hasText: 'All' }).click();
-    await page.waitForTimeout(500);
-    expect(await cards.count()).toBeGreaterThanOrEqual(10);
+    const allTab = page.locator('[data-slot="tabs-trigger"]', { hasText: 'All' });
+    await allTab.click();
+    await expect(allTab).toHaveAttribute('aria-selected', 'true');
+    await expect.poll(() => cards.count()).toBeGreaterThanOrEqual(10);
   });
 
   test('about page has tech stack tabs and journey', async ({ page }) => {
@@ -110,18 +118,21 @@ test.describe('page content checks', () => {
   });
 
   test('about page tech stack tab switching works', async ({ page }) => {
-    await page.goto('/about', { waitUntil: 'domcontentloaded' });
-    await page.waitForTimeout(1000);
+    // networkidle for the same reason as the projects filter: a lazy route is painted
+    // long before it can be clicked.
+    await page.goto('/about', { waitUntil: 'networkidle' });
 
-    // Click "Backend" tab
-    await page.locator('[data-slot="tabs-trigger"]', { hasText: 'Backend' }).click();
-    await page.waitForTimeout(500);
-    // Should show backend tech badges
+    // Same reveal-settling as the projects filter.
+    const backend = page.locator('[data-slot="tabs-trigger"]', { hasText: 'Backend' });
+    await backend.scrollIntoViewIfNeeded();
+    await page.waitForTimeout(1200);
+    await backend.click();
+    await expect(backend).toHaveAttribute('aria-selected', 'true');
     await expect(page.locator('text=Node.js')).toBeVisible();
 
-    // Click "AI & Tools" tab
-    await page.locator('[data-slot="tabs-trigger"]', { hasText: 'AI' }).click();
-    await page.waitForTimeout(500);
+    const ai = page.locator('[data-slot="tabs-trigger"]', { hasText: 'AI' });
+    await ai.click();
+    await expect(ai).toHaveAttribute('aria-selected', 'true');
     await expect(page.locator('text=LangChain')).toBeVisible();
   });
 
@@ -129,7 +140,7 @@ test.describe('page content checks', () => {
     await page.goto('/contact', { waitUntil: 'domcontentloaded' });
     await expect(page.locator('text=Talk it through')).toBeVisible();
     // Contact info
-    await expect(page.locator('text=Leeds, Yorkshire')).toBeVisible();
+    await expect(page.getByText('Leeds, Yorkshire', { exact: true })).toBeVisible();
     await expect(page.locator('text=dev@thomasjbutler.me')).toBeVisible();
     // Form fields
     await expect(page.locator('input[name="name"]')).toBeVisible();
@@ -154,13 +165,16 @@ test.describe('page content checks', () => {
 
   test('updates page has timeline milestones', async ({ page }) => {
     await page.goto('/updates', { waitUntil: 'domcontentloaded' });
-    await expect(page.locator('text=Dev Journey')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Dev Journey' })).toBeVisible();
     // Scroll to reveal all timeline cards
     await autoScroll(page);
     await page.waitForTimeout(1000);
-    // Check specific milestones exist
-    await expect(page.locator('text=The Beginning')).toBeVisible();
-    await expect(page.locator('text=Started My Coding Journey')).toBeVisible();
+    // Real entry titles from src/lib/timeline.ts. This used to check "The Beginning",
+    // which is an About page milestone and has never existed on this page: text= is a
+    // case-insensitive substring match, so it was quietly matching "...the beginning of
+    // the career change" inside an entry's prose.
+    await expect(page.getByText('Started My Coding Journey', { exact: true })).toBeVisible();
+    await expect(page.getByText('Work Coach at the DWP', { exact: true })).toBeVisible();
     // Check we have multiple timeline cards
     const cards = page.locator('[data-slot="card"]');
     expect(await cards.count()).toBeGreaterThanOrEqual(8);
@@ -172,22 +186,26 @@ test.describe('page content checks', () => {
       test.skip();
     }
     await page.goto('/', { waitUntil: 'domcontentloaded' });
-    await expect(page.locator('text=Hey, I\'m Tom')).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1 })).toContainText("Hey, I'm Tom");
 
-    // Navigate to Projects via nav link
+    // Generous timeouts on every hop from here. A client-side navigation into a lazy
+    // route takes seconds in a headless browser: AnimatePresence mode="wait" holds the
+    // outgoing page for its exit, then the route chunk loads, then the enter animation
+    // runs, all while the rain canvas is being software-rasterised. Measured at ~10s a
+    // hop locally. It is a headless cost, not a user-facing one.
     await page.locator('nav a', { hasText: 'Projects' }).first().click();
     await page.waitForURL('/projects');
-    await expect(page.locator('h1', { hasText: 'Projects' })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1 })).toContainText(/projects/i, { timeout: 20000 });
 
     // Navigate to About
     await page.locator('nav a', { hasText: 'About' }).first().click();
     await page.waitForURL('/about');
-    await expect(page.locator('text=why this site exists')).toBeVisible();
+    await expect(page.locator('text=why this site exists')).toBeVisible({ timeout: 20000 });
 
     // Navigate to Contact
     await page.locator('nav a', { hasText: 'Contact' }).first().click();
     await page.waitForURL('/contact');
-    await expect(page.locator('text=Talk it through')).toBeVisible();
+    await expect(page.locator('text=Talk it through').first()).toBeVisible({ timeout: 20000 });
   });
 
   test('header is sticky and visible on scroll', async ({ page }) => {

--- a/index.html
+++ b/index.html
@@ -26,6 +26,15 @@
           var stored = localStorage.getItem('theme');
           var dark = stored ? stored === 'dark' : !matchMedia('(prefers-color-scheme: light)').matches;
           if (dark) document.documentElement.classList.add('dark');
+
+          // Same call FxProvider's getInitialFx makes. Without it, a visitor who has
+          // switched effects off still gets a frame of scanlines and vignette before the
+          // provider's effect runs. This only sets a class; React renders the same markup
+          // either way, so it cannot cause a hydration mismatch.
+          var fx = localStorage.getItem('v5:fx');
+          var fxOn = fx === 'on' ? true : fx === 'off' ? false
+            : !matchMedia('(prefers-reduced-motion: reduce)').matches;
+          if (!fxOn) document.documentElement.classList.add('fx-off');
         } catch (e) {
           document.documentElement.classList.add('dark');
         }

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,6 +1,6 @@
 # Tom Butler
 
-> Software developer in Leeds, Yorkshire. Career changer: hospitality, two years as a DWP Work Coach, then a standing start in late 2022 to building AI systems. Currently looking for full-time work: junior for general software, any non-senior level for AI. This site is the personal work, built because I wanted it to exist. The paid work is at https://thomasjbutler.me.
+> Software developer in Leeds, Yorkshire. Career changer: professional cricket, commercial diving and financial paraplanning, then two years as a DWP Work Coach, then a standing start in early 2022 to building AI systems. Currently looking for full-time work: junior for general software, any non-senior level for AI. This site is the personal work, built because I wanted it to exist. The paid work is at https://thomasjbutler.me.
 
 Contact: dev@thomasjbutler.me
 

--- a/scripts/routes.mjs
+++ b/scripts/routes.mjs
@@ -56,7 +56,7 @@ export const ROUTE_META = [
     module: 'src/pages/AboutPage.tsx',
     title: 'About | Tom Butler',
     description:
-      'Career changer. Hospitality, two years as a DWP Work Coach, then a standing start in late 2022 to shipping AI systems. Software developer in Leeds, Yorkshire.',
+      'Career changer. Hospitality, two years as a DWP Work Coach, then a standing start in early 2022 to shipping AI systems. Software developer in Leeds, Yorkshire.',
   },
   {
     path: '/contact',

--- a/src/app.css
+++ b/src/app.css
@@ -1609,3 +1609,41 @@
     padding-block: 0.3rem;
   }
 }
+
+/* ─── Theme wipe ───
+   The new theme arrives as a circle expanding from the toggle instead of a hard cut to
+   near-white. Coordinates and radius come from ThemeContext as --vt-x / --vt-y / --vt-r;
+   the fallbacks here are what a transition started without an origin gets.
+
+   Outside @layer on purpose: these pseudo-elements live on the document root, and the UA
+   sheet that styles them is not part of the authored cascade. */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+  /* The UA default is plus-lighter, which is right for a cross-fade and wrong for a
+     wipe: the two themes would add together into a white flash at the boundary. */
+  mix-blend-mode: normal;
+}
+::view-transition-old(root) {
+  z-index: 0;
+}
+::view-transition-new(root) {
+  z-index: 1;
+  animation: fx-theme-wipe 450ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes fx-theme-wipe {
+  from {
+    clip-path: circle(0 at var(--vt-x, 50%) var(--vt-y, 50%));
+  }
+  to {
+    clip-path: circle(var(--vt-r, 150vmax) at var(--vt-x, 50%) var(--vt-y, 50%));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation: none;
+  }
+}

--- a/src/app.css
+++ b/src/app.css
@@ -201,8 +201,12 @@
 .dark {
   --background: oklch(0.08 0.01 145);
   --foreground: oklch(0.97 0.005 145);
-  /* Nearly opaque: a card is a reading surface, and the rain runs behind it. */
-  --card: oklch(0.11 0.015 145 / 0.94);
+  /*
+   * Opaque, not 0.94. A card is a reading surface and the rain runs behind it, so that
+   * last 6% was live animation showing through every project card, timeline entry and
+   * form on the site. The card keeps its border and shadow; the rain still frames it.
+   */
+  --card: oklch(0.11 0.015 145);
   --card-foreground: oklch(0.97 0.005 145);
   --popover: oklch(0.11 0.015 145);
   --popover-foreground: oklch(0.97 0.005 145);
@@ -604,8 +608,13 @@
     inset: 0;
     z-index: 70;
     pointer-events: none;
-    /* Was 0.275. These sit over everything and dim the whole page. */
-    opacity: 0.15;
+    /*
+     * Was 0.275, then 0.15. These sit at z-70, ABOVE every word on the site, so their
+     * opacity is a tax on the contrast of all body copy: at 0.15 a 0.28-alpha black bar
+     * covered a third of every text row. 0.09 keeps the CRT texture and stops it being
+     * something you read through.
+     */
+    opacity: 0.09;
     background: repeating-linear-gradient(
       0deg,
       rgba(0, 0, 0, 0.28) 0 1px,
@@ -639,15 +648,38 @@
     display: none;
   }
 
+  /*
+   * Effects off means off, including the CRT layers.
+   *
+   * These used to survive the toggle, which is why the page was still hard to read with
+   * the rain switched off: the thing dimming the text was never the rain, it was a
+   * vignette and a scanline grid painted on top of it. `fx-off` is set on
+   * documentElement by FxProvider, so this is a class swap and not a conditional render:
+   * the markup stays identical between the server and the client, and the prerendered
+   * tree survives hydration.
+   */
+  :root.fx-off .fx-scanlines,
+  :root.fx-off .fx-vignette {
+    display: none;
+  }
+
   .fx-vignette {
     position: fixed;
     inset: 0;
     z-index: 69;
     pointer-events: none;
+    /*
+     * Transparent to 72%, not 58%, and 0.22 black rather than 0.38.
+     *
+     * At the old numbers the darkening started well inside the max-w-5xl text column, so
+     * the first and last words of most lines were being read through up to 38% black. On
+     * a phone almost the whole page sat in that band. It is atmosphere for the edges of
+     * the screen, not a filter over the copy.
+     */
     background: radial-gradient(
       ellipse at 50% 38%,
-      transparent 58%,
-      rgba(0, 0, 0, 0.38) 100%
+      transparent 72%,
+      rgba(0, 0, 0, 0.22) 100%
     );
   }
   :root:not(.dark) .fx-vignette {
@@ -1488,11 +1520,14 @@
     inset: 0 clamp(-3rem, calc((100% - 100vw) / 2), 0px);
     z-index: 0;
     pointer-events: none;
+    /* The feather used to run to 6% and 94%, which on a 1024px column is ~60px of each
+       line with no scrim under it at all. 1.5% still softens the edge without leaving the
+       first and last words sitting on bare rain. */
     background: linear-gradient(
       90deg,
       transparent 0%,
-      oklch(0.08 0.01 145 / 0.95) 6%,
-      oklch(0.08 0.01 145 / 0.95) 94%,
+      oklch(0.08 0.01 145 / 0.95) 1.5%,
+      oklch(0.08 0.01 145 / 0.95) 98.5%,
       transparent 100%
     );
   }
@@ -1500,8 +1535,8 @@
     background: linear-gradient(
       90deg,
       transparent 0%,
-      oklch(0.985 0.002 145 / 0.88) 6%,
-      oklch(0.985 0.002 145 / 0.88) 94%,
+      oklch(0.985 0.002 145 / 0.88) 1.5%,
+      oklch(0.985 0.002 145 / 0.88) 98.5%,
       transparent 100%
     );
   }

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -19,7 +19,12 @@ export function ThemeToggle() {
     <Button
       variant="ghost"
       size="icon"
-      onClick={toggleTheme}
+      onClick={(event) => {
+        // The button's own centre rather than the pointer: a keyboard activation
+        // reports clientX/clientY of 0, which would wipe from the top-left corner.
+        const rect = event.currentTarget.getBoundingClientRect();
+        toggleTheme({ x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 });
+      }}
       aria-label={`Switch to ${dark ? 'light' : 'dark'} mode`}
       className="text-muted-foreground hover:text-primary"
     >

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -17,7 +17,7 @@ function renderHeader() {
 describe('Header', () => {
   it('renders the site title', () => {
     renderHeader();
-    expect(screen.getByRole('link', { name: /thomas_butler/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /tom_butler/i })).toBeInTheDocument();
   });
 
   it('renders all navigation links', () => {

--- a/src/components/home/ProofSection.tsx
+++ b/src/components/home/ProofSection.tsx
@@ -23,29 +23,11 @@ export function ProofSection() {
       />
 
       <div className="grid gap-4 lg:grid-cols-5">
-        {/* The case study leads: it is the strongest asset on the site. */}
-        <Card className="fx-lead-card lg:col-span-3">
-          <CardContent className="flex h-full flex-col pt-6">
-            <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-primary/90">
-              case_study
-            </p>
-            <h3 className="mt-2 font-heading text-lg font-bold leading-snug text-foreground">
-              {CASE_STUDY.title}
-            </h3>
-            <p className="mt-3 flex-1 text-sm leading-relaxed text-muted-foreground">
-              {CASE_STUDY.subtitle}
-            </p>
-            <div className="mt-5">
-              <Button asChild>
-                <Link to="/case-study">
-                  Read the case study <ArrowRight className="size-4" />
-                </Link>
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card className="lg:col-span-2">
+        {/* The recent-work list takes the wide column. It carries five entries that were
+            wrapping onto two lines each in the narrow one, while the case study card sat
+            in the wide column half empty. The case study keeps fx-lead-card, so it is
+            still the loudest thing here, just no longer the widest. */}
+        <Card className="lg:col-span-3">
           <CardContent className="pt-6">
             <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
               recently
@@ -77,6 +59,28 @@ export function ProofSection() {
             </ul>
           </CardContent>
         </Card>
+
+        <Card className="fx-lead-card lg:col-span-2">
+          <CardContent className="flex h-full flex-col pt-6">
+            <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-primary/90">
+              case_study
+            </p>
+            <h3 className="mt-2 font-heading text-lg font-bold leading-snug text-foreground">
+              {CASE_STUDY.title}
+            </h3>
+            <p className="mt-3 flex-1 text-sm leading-relaxed text-muted-foreground">
+              {CASE_STUDY.subtitle}
+            </p>
+            <div className="mt-5">
+              <Button asChild>
+                <Link to="/case-study">
+                  Read the case study <ArrowRight className="size-4" />
+                </Link>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+
       </div>
     </Reveal>
   );

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -36,13 +36,18 @@ export function Header({ onOpenPalette }: { onOpenPalette?: () => void }) {
 
   return (
     <header className="sticky top-0 z-50 bg-background/80 backdrop-blur-md shadow-[0_1px_20px_color-mix(in_oklab,var(--primary)_4%,transparent)]">
-      <div className="mx-auto flex h-14 max-w-5xl items-center justify-between px-6">
+      {/* relative z-50, and it is load-bearing. <header> is sticky z-50 with a
+          backdrop-blur, which makes it a stacking context. The mobile backdrop below is a
+          fixed inset-0 z-40 sibling of this bar, and this bar had no z-index at all, so it
+          painted underneath: with the menu open, the close button sat under a 60% black
+          wash and a blur, and looked like it had vanished. */}
+      <div className="relative z-50 mx-auto flex h-14 max-w-5xl items-center justify-between px-6">
         {/* Logo */}
         <Link
           to="/"
           className="font-mono text-sm font-semibold text-primary transition-colors hover:text-primary/80"
         >
-          <span className="text-primary/90">&gt;</span> thomas_butler
+          <span className="text-primary/90">&gt;</span> tom_butler
         </Link>
 
         {/* Desktop nav */}
@@ -118,7 +123,7 @@ export function Header({ onOpenPalette }: { onOpenPalette?: () => void }) {
             aria-hidden="true"
           />
           <nav
-            className="fixed inset-x-0 top-14 z-50 border-b border-border bg-background/95 backdrop-blur-md p-4 md:hidden"
+            className="fixed inset-x-0 top-14 z-50 border-b border-border bg-background p-4 md:hidden"
             aria-label="Mobile navigation"
           >
             <div className="flex flex-col gap-1">

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,12 +1,27 @@
 import { createContext, useCallback, useEffect, useState, type ReactNode } from 'react';
+import { flushSync } from 'react-dom';
 
 type Theme = 'dark' | 'light';
 
+/** Where the wipe starts from. Omitted (the command palette) means the middle. */
+export interface WipeOrigin {
+  x: number;
+  y: number;
+}
+
 interface ThemeContextValue {
   theme: Theme;
-  setTheme: (theme: Theme) => void;
-  toggleTheme: () => void;
+  setTheme: (theme: Theme, origin?: WipeOrigin) => void;
+  toggleTheme: (origin?: WipeOrigin) => void;
 }
+
+/**
+ * Not in TypeScript's DOM lib in every version, and declaring it globally risks
+ * clashing with a future one. A local cast keeps it to this file.
+ */
+type WithViewTransition = Document & {
+  startViewTransition?: (callback: () => void) => unknown;
+};
 
 export const ThemeContext = createContext<ThemeContextValue | null>(null);
 
@@ -29,14 +44,51 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
-  const setTheme = useCallback((t: Theme) => {
-    setThemeState(t);
-    localStorage.setItem('theme', t);
-    applyTheme(t);
+  const setTheme = useCallback((t: Theme, origin?: WipeOrigin) => {
+    const commit = () => {
+      setThemeState(t);
+      localStorage.setItem('theme', t);
+      applyTheme(t);
+    };
+
+    const root = document.documentElement;
+    const start = (document as WithViewTransition).startViewTransition;
+
+    /*
+     * Three ways to end up with the old instant switch, and all three are deliberate:
+     * a browser without the API (Firefox today), an OS reduced-motion preference, and
+     * the site's own effects toggle, which is the WCAG 2.2.2 control and has to govern
+     * every animation on the page rather than just the rain.
+     */
+    const wipe =
+      typeof start === 'function' &&
+      !window.matchMedia('(prefers-reduced-motion: reduce)').matches &&
+      !root.classList.contains('fx-off');
+
+    if (!wipe) {
+      commit();
+      return;
+    }
+
+    const x = origin?.x ?? window.innerWidth / 2;
+    const y = origin?.y ?? window.innerHeight / 2;
+    // Reach the furthest corner, or the circle stops short and leaves a ring of the
+    // old theme in the corner opposite the button.
+    const radius = Math.hypot(
+      Math.max(x, window.innerWidth - x),
+      Math.max(y, window.innerHeight - y)
+    );
+    root.style.setProperty('--vt-x', `${x}px`);
+    root.style.setProperty('--vt-y', `${y}px`);
+    root.style.setProperty('--vt-r', `${radius}px`);
+
+    // flushSync, because the snapshot is taken when this callback returns. Without it
+    // React commits afterwards and the toggle's own icon swaps a beat late.
+    start.call(document, () => flushSync(commit));
   }, [applyTheme]);
 
-  const toggleTheme = useCallback(() => {
-    setTheme(theme === 'dark' ? 'light' : 'dark');
+  const toggleTheme = useCallback((origin?: WipeOrigin) => {
+    setTheme(theme === 'dark' ? 'light' : 'dark', origin);
   }, [theme, setTheme]);
 
   // Apply on mount

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -28,7 +28,7 @@ export const LINKS = {
  * here even though the wordmark says it too: a hiring manager reads the H1, not the header.
  */
 
-export const HERO_EYEBROW = '// software developer · leeds, yorkshire';
+export const HERO_EYEBROW = '_software developer · leeds, yorkshire';
 
 /** Two lines on purpose: the second line is the turn. */
 export const HERO_H1 = ["Hey, I'm Tom.", 'I build things.'];

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -306,9 +306,9 @@ export const projects: Project[] = [
   {
     id: 'morpheus',
     name: 'Morpheus',
-    description: 'Intelligent document Q&A with semantic search and source citations using RAG.',
-    longDescription: 'An intelligent document reasoning system with a Matrix-themed interface. Upload your private documents and ask questions in natural language. Private by design: fresh Pinecone vector namespace per session, pay only for tokens used. Claude generates accurate answers from your specific documents with source citations.',
-    topics: ['Pinecone', 'Anthropic', 'LangChain', 'FastAPI'],
+    description: 'Ask questions about your own documents and get answers where every claim points at a real passage. Runs entirely on your machine.',
+    longDescription: 'Upload a PDF, Word file, text or Markdown, ask a question in plain English, and get an answer where every [n] marker points at a passage the model actually read. Retrieval is hybrid, vector search and BM25 keyword search fused, and a local model writes the answer. Ollama runs the models, LanceDB holds the index on disk, and at inference time nothing leaves the machine: upload, indexing, retrieval and generation all talk to 127.0.0.1 and nowhere else. The citation check is the part I am proudest of. Every marker is verified against the retrieved passages while the answer is still streaming, so a marker the model invented never reaches the screen, and an answer that cites nothing is flagged "not grounded" rather than passed off as fact. If the documents do not contain the answer, it says so instead of guessing.',
+    topics: ['Ollama', 'LanceDB', 'FastAPI', 'Next.js'],
     language: 'Python',
     category: 'ai',
     links: { demo: 'https://morpheusrag.vercel.app', github: 'https://github.com/ThomasJButler/Morpheus' },
@@ -326,7 +326,10 @@ export const projects: Project[] = [
       },
       diagram: {
         src: MEDIA.morpheus.diagram,
-        caption: 'Your documents, a vector namespace that exists only for the session, and an answer that cites where it came from. The generation step is drawn green: it is moving to Ollama and local models.',
+        // The diagram still shows the hosted build this project started as. The green
+        // generation step it described as "moving to Ollama" has now moved, along with
+        // the vector store; the artwork is the last thing left to redraw.
+        caption: 'Your documents, an index that lives on your own disk, and an answer that cites where it came from. Every step of this runs on the machine in front of you.',
       },
       wireframe: {
         src: MEDIA.morpheus.wireframe,
@@ -335,7 +338,13 @@ export const projects: Project[] = [
     },
     videos: ['https://res.cloudinary.com/depqttzlt/video/upload/vc_auto,q_auto,w_960/v1767706547/2_1080_N_s5t1ww.mp4'],
     status: 'completed',
-    highlights: ['Private by design: fresh namespace per session', 'Semantic search with Pinecone vectors', 'Source citations for every answer', 'Cost effective: pay only for tokens used'],
+    featured: true,
+    highlights: [
+      'Runs entirely on your machine. Nothing leaves it at inference time',
+      'Every citation checked against the retrieved passage, as it streams',
+      'Hybrid retrieval: vector search and BM25 keyword search, fused',
+      'Says "not grounded" rather than guessing',
+    ],
   },
   {
     id: 'reviewbot-protocol',
@@ -469,7 +478,6 @@ export const projects: Project[] = [
       cover: 'https://res.cloudinary.com/depqttzlt/image/upload/v1766580999/logo_ofodr8.svg',
       gallery: MEDIA['commercial-portfolio'].gallery,
     },
-    featured: true,
   },
   // The LFC News App was here and stays retired. It read r/LiverpoolFC through the Reddit
   // API, the terms changed under it, and its only link is a demo that depends on them. A

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -238,6 +238,43 @@ export const projects: Project[] = [
     highlights: ['Grounded answers with four-dimension confidence scoring', 'Outputs DOCX / XLSX / JSON', 'n8n orchestration + per-question cost/latency auditing', '480+ tests, CI, test-driven throughout'],
   },
   {
+    id: 'offshore-property-map',
+    name: 'Offshore Property Map',
+    description: 'Who owns England and Wales, from where? Entity resolution across two government registers that share no common identifier.',
+    longDescription: 'HM Land Registry publishes which titles are owned by overseas companies. Companies House publishes who is behind those companies. Neither register carries a key that points at the other, so the join has to be built: normalise the names and addresses, score candidate pairs with Splink, and put every match in front of a human before it counts. The output is FollowTheMoney format, so it drops into the OpenSanctions and OpenAleph ecosystem rather than being another dead-end dataset. The rule the whole pipeline is built around is that nothing publishes on a hunch. A match set is only publishable once the Clopper-Pearson lower bound on precision clears 0.95 over a labelled sample, and that result is written into a certificate hashed against the exact scores file it was measured on. The export refuses to emit machine-made links without one. It publishes what the registers record and nothing beyond that, and it never presents an automated match as fact.',
+    topics: ['Splink', 'DuckDB', 'FollowTheMoney', 'Entity resolution'],
+    language: 'Python',
+    category: 'ai',
+    // No links. The repo is private, and the Land Registry licence carries attribution,
+    // address-use and deletion duties that a public demo could not honour.
+    links: {},
+    status: 'in-progress',
+    highlights: [
+      'Two public registers, no shared key, real consequences for a wrong match',
+      'Probabilistic matching with Splink, over DuckDB',
+      'A gate certificate: nothing publishes below a 0.95 precision lower bound',
+      'Provenance on every row, and human judgements that accumulate',
+    ],
+  },
+  {
+    id: 'octopus-job-hunter',
+    name: 'OctopusJobHunter',
+    description: 'Extra hands for a job search. Sixteen job boards in ten seconds, a tailored CV in four formats, and a tracker you own.',
+    longDescription: 'Built from my own job search, which is the only reason it is any good: the rules in it were paid for the hard way. It searches sixteen specialist boards through official licensed feeds, generates a CV tailored to a specific advert in four formats (a designed PDF and Word file for people, plain versions for the parsers), tracks every application in a CSV and an Excel dashboard that never locks or asks you to log in, and preps interview answers from your own material. The intelligence lives in plain markdown playbooks rather than in code, so Claude, Codex or a model running on your own machine can all follow them. That last option is the point: your employment history is sensitive, and it should not have to leave your laptop to be useful. Two things it will not do, deliberately. It will not write experience you do not have, and it will not apply on your behalf.',
+    topics: ['Python', 'ReportLab', 'Playbooks', 'Local models'],
+    language: 'Python',
+    category: 'ai',
+    // Private: it holds a real profile and a real application history.
+    links: {},
+    status: 'completed',
+    highlights: [
+      'Sixteen specialist boards through official feeds, in about ten seconds',
+      'One CV library, four output formats per role',
+      'Markdown playbooks, so any agent (or a local model) can run it',
+      'Never applies for you. That is a decision, not a gap',
+    ],
+  },
+  {
     id: 'ai-code-generator',
     // The product calls itself AI Code Generator everywhere: the repo, the page h1, the
     // deployed title and all the artwork. Only this record said "LangChain", which put a

--- a/src/lib/timeline.ts
+++ b/src/lib/timeline.ts
@@ -610,9 +610,9 @@ export const timelineData: TimelineEntry[] = [
     title: 'Apprentice developer at Fuelius',
     location: 'Leeds, Yorkshire',
     institution: 'Fuelius',
-    description: 'First job in software, at a HubSpot partner agency. Sixteen months, twelve named clients, and a Level 4 Software Developer apprenticeship with Estio studied alongside it. Umbraco, HubSpot, C# and .NET, SCSS, and a lot of client calls.',
+    description: 'First job in software, at a HubSpot partner agency. Eighteen months, twelve named clients, and a Level 4 Software Developer apprenticeship with Estio studied alongside it. Umbraco, HubSpot, C# and .NET, SCSS, and a lot of client calls.',
     achievements: [
-      'Twelve named clients in sixteen months, an NHS trust and two arena venues among them',
+      'Twelve named clients in eighteen months, an NHS trust and two arena venues among them',
       'Implementation lead under a senior architect on a seven-brand HubSpot migration',
       'Level 4 Software Developer apprenticeship with Estio, studied 2023-24',
       'Umbraco, HubSpot and HubL, C#/.NET, SCSS, Azure DevOps'
@@ -665,16 +665,18 @@ export const timelineData: TimelineEntry[] = [
   {
     id: 24,
     year: 2022,
-    month: 11,
-    date: formatDate(2022, 11),
+    month: 2,
+    date: formatDate(2022, 2),
     title: 'Started My Coding Journey',
     location: 'Leeds, Yorkshire',
     institution: 'Self-Directed Learning',
-    description: 'Started teaching myself to code while still at the DWP, evenings and weekends. The beginning of an intensive self-learning period that turned into a career change.',
+    description: 'Started teaching myself to code from a standing start, while still at the DWP. Evenings and weekends around a full-time job, and the beginning of the career change.',
     achievements: [
       'Began learning programming fundamentals and computer science basics',
-      'Discovered ChatGPT and used it as a learning companion',
       'Studied online through various platforms and tutorials',
+      // ChatGPT did not exist until the November. It changed the pace of the learning,
+      // it did not start it.
+      'AI tools arrived later that year and changed how fast I could learn',
       'Started exploring game development concepts and engines'
     ],
     links: [],
@@ -710,10 +712,10 @@ export const timelineData: TimelineEntry[] = [
     title: 'Early Tech Passion & Life Journey',
     location: 'Leeds, Yorkshire',
     institution: 'Life Experience',
-    description: 'From childhood, I was fascinated by technology and gaming, loving the simplicity and UI design of classic games. Despite this passion, life took me on different paths: professional cricket, then commercial diving. It wasn\'t until AI emerged that I realised I could finally pursue my true calling.',
+    description: 'From childhood, I was fascinated by technology and gaming, loving the simplicity and UI design of classic games. Despite this passion, life took me on different paths: professional cricket, commercial diving, then financial paraplanning. It wasn\'t until AI emerged that I realised I could finally pursue my true calling.',
     achievements: [
       'Childhood obsession with tech: jailbreaking an iPod Touch, installing Cydia repos',
-      'Pursued professional cricket, then commercial diving',
+      'Professional cricket, commercial diving, then paraplanning in financial services',
       'Always the person with the app ideas and no way to build them',
       'AI tools closed that gap, and I\'ve been making up for it since'
     ],

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -107,7 +107,7 @@ export function AboutPage() {
           transition={{ duration: 0.4 }}
           className="font-mono text-xs uppercase tracking-widest text-muted-foreground"
         >
-          // about
+          _About
         </motion.p>
 
         {/*

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -50,7 +50,7 @@ const JOURNEY_MILESTONES = [
     era: '2014-20',
     title: 'Everything but code',
     description:
-      'Hospitality, events, a conveyancing desk in Southport, and two seasons of Victorian Premier League cricket in Melbourne. Not a line of code in any of it.',
+      'Two seasons of Victorian Premier League cricket in Melbourne, commercial diving, paraplanning in financial services, and a conveyancing desk in Southport. Not a line of code in any of it.',
     icon: Briefcase,
   },
   {
@@ -61,17 +61,17 @@ const JOURNEY_MILESTONES = [
     icon: Users,
   },
   {
-    era: 'Nov 2022',
+    era: 'Early 2022',
     title: 'First line of code',
     description:
-      'Started teaching myself while still at the DWP. Cloud Engineering and Data Science bootcamp with The Growth Company in 2023.',
+      'From a standing start, teaching myself around a full-time job at the DWP. Cloud Engineering and Data Science bootcamp with The Growth Company in 2023.',
     icon: Code,
   },
   {
     era: '2023-24',
     title: 'Fuelius',
     description:
-      'Sixteen months as an apprentice full-stack developer at a HubSpot partner agency. Twelve named clients, an NHS trust among them. Level 4 apprenticeship, studied 2023-24. Made redundant December 2024.',
+      'Eighteen months as an apprentice full-stack developer at a HubSpot partner agency. Twelve named clients, an NHS trust among them. Level 4 apprenticeship, studied 2023-24. Made redundant December 2024.',
     icon: Building2,
   },
   {

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -154,21 +154,22 @@ export function AboutPage() {
         />
         <div className="fx-scrim max-w-2xl space-y-4 leading-relaxed text-muted-foreground">
           <p>
-            Programming is not just a profession for me, it&apos;s a passion. There&apos;s
-            something magical about transforming ideas into reality through code. The ability
-            to create something from nothing, to build tools that solve real problems, and to
-            see the immediate impact of your work is incredibly satisfying.
+            I never got into software for the paycheck. I got into it to help people at scale
+            and to use the creative side of my brain. Money matters, of course, but if it
+            means earning a bit less and loving what I do, that&apos;s the trade I&apos;ll
+            take every time.
           </p>
           <p>
-            What truly captivates me is the puzzle-solving. Each challenge is an opportunity
-            to break down a complex problem into an elegant solution, and the moment when
-            everything clicks into place, when the code finally works after hours of
-            debugging, is pure joy.
+            I&apos;m always trying to improve my code and my fundamentals, because
+            that&apos;s the only part of this job that doesn&apos;t change every few years.
+            Whatever I&apos;m learning, I build something alongside it. Some of those side
+            projects have properly kicked on since, and they&apos;re how I keep going deeper
+            on one thing over time.
           </p>
           <p>
-            The technology landscape never stops evolving, and that is what keeps me
-            energised. There is always a new framework to explore, a better pattern to learn,
-            or an innovative approach to discover.
+            Software should give people time back, not take it from them. Most of what I
+            build is aimed at that: making tech adapt to humans rather than the other way
+            round.
           </p>
         </div>
       </MotionSection>

--- a/src/pages/CaseStudyPage.tsx
+++ b/src/pages/CaseStudyPage.tsx
@@ -28,7 +28,7 @@ export function CaseStudyPage() {
     <div className="fx-page mx-auto max-w-5xl px-6 py-16">
       <Reveal>
         <p className="font-mono text-xs tracking-[0.2em] text-primary/90">
-          <DecodeText text="// case_study" step={20} />
+          <DecodeText text="_Case study" step={20} />
         </p>
         <h1 className="mt-3 max-w-3xl font-heading text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
           {CASE_STUDY.title}

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -43,11 +43,19 @@ export function ContactPage() {
       <LinkedInBanner />
       {/* Page Header */}
       <section className="py-16 text-center">
+        <motion.p
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.4 }}
+          className="font-mono text-xs uppercase tracking-widest text-muted-foreground"
+        >
+          _Contact
+        </motion.p>
         <motion.h1
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
-          className="font-heading text-4xl font-bold tracking-tight text-foreground sm:text-5xl"
+          className="mt-3 font-heading text-4xl font-bold tracking-tight text-foreground sm:text-5xl"
         >
           Talk it through
         </motion.h1>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { ArrowRight, ExternalLink, Sparkles } from 'lucide-react';
+import { Activity, ArrowRight, ExternalLink } from 'lucide-react';
 import { GithubIcon } from '@/components/icons';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -34,7 +34,7 @@ export function HomePage() {
       <Reveal as="section" className="py-4">
         <div className="rounded-lg border border-primary/20 bg-primary/[0.03] p-5">
           <div className="mb-3 flex items-center gap-2">
-            <Sparkles className="size-3.5 text-primary" />
+            <Activity className="size-3.5 text-primary" />
             <span className="font-mono text-xs uppercase tracking-wider text-primary/90">now</span>
           </div>
           <p className="text-sm leading-relaxed text-foreground/80">{NOW_COPY}</p>

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -119,10 +119,14 @@ export function ProjectsPage() {
 
   return (
     <div className="fx-page mx-auto max-w-5xl px-6 py-16">
-      {/* No "// projects" eyebrow above this: it sat directly over an h1 reading
-          "Projects", so the page opened by saying its own name twice. */}
+      {/* Same header shape as About and the case study: an underscore-prefixed label,
+          then the heading. The eyebrow reads as a path rather than as a repeat of the h1,
+          which is why "// projects" over "Projects" did not work and this does. */}
       <MotionSection>
-        <h1 className="font-heading text-3xl font-bold tracking-tight">Projects</h1>
+        <p className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+          _Projects
+        </p>
+        <h1 className="mt-3 font-heading text-3xl font-bold tracking-tight">Projects</h1>
         <p className="mt-2 text-sm text-muted-foreground">
           AI, web and mobile work, plus the learning projects that came first.
         </p>

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -119,15 +119,14 @@ export function ProjectsPage() {
 
   return (
     <div className="fx-page mx-auto max-w-5xl px-6 py-16">
-      {/* Same header shape as About and the case study: an underscore-prefixed label,
-          then the heading. The eyebrow reads as a path rather than as a repeat of the h1,
-          which is why "// projects" over "Projects" did not work and this does. */}
+      {/* The label IS the h1. There was a big "Projects" heading under it saying the same
+          word a second time; this keeps the page's one h1 for crawlers and screen readers
+          without printing the title twice. */}
       <MotionSection>
-        <p className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+        <h1 className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
           _Projects
-        </p>
-        <h1 className="mt-3 font-heading text-3xl font-bold tracking-tight">Projects</h1>
-        <p className="mt-2 text-sm text-muted-foreground">
+        </h1>
+        <p className="mt-3 text-sm text-muted-foreground">
           AI, web and mobile work, plus the learning projects that came first.
         </p>
       </MotionSection>

--- a/src/pages/UpdatesPage.tsx
+++ b/src/pages/UpdatesPage.tsx
@@ -67,7 +67,7 @@ export function UpdatesPage() {
           transition={{ duration: 0.4 }}
           className="font-mono text-xs uppercase tracking-widest text-muted-foreground"
         >
-          // timeline
+          _Timeline
         </motion.p>
         <motion.h1
           initial={{ opacity: 0, y: 20 }}
@@ -210,7 +210,7 @@ export function UpdatesPage() {
 
       {/* CTA */}
       <section className="pb-24 text-center">
-        <p className="font-mono text-xs text-muted-foreground">// what&apos;s next?</p>
+        <p className="font-mono text-xs text-muted-foreground">_what&apos;s next?</p>
         <h2 className="mt-2 font-heading text-2xl font-bold text-foreground">
           Let&apos;s Build Something
         </h2>


### PR DESCRIPTION
## What

Twelve commits of follow-up after the job-search repoint shipped. Three groups: content that had gone stale, three UI bugs, and a readability pass on the dark theme.

## Why

Morpheus was rebuilt to run entirely on Ollama and every word on its card still described the hosted version. Two of the three things I've actually spent this year on (the Offshore Property Map and OctopusJobHunter) weren't on the projects page at all. And my GitHub profile readme said early 2022 and eighteen months while the site said November 2022 and sixteen, which is exactly the kind of thing an employer notices when they read both.

Then three things that were annoying me in use: the mobile menu's close button was invisible, dark mode was hard to read even with the rain switched off, and the theme switch was a hard cut to near-white.

## Content

- **Morpheus rewritten and featured.** Ollama, LanceDB, hybrid retrieval, and the citation check that verifies every `[n]` against the retrieved passage while the answer streams. It replaces the commercial portfolio in the featured six.
- **Offshore Property Map** and **OctopusJobHunter** added. Both private repos, so a write-up and no Code link, like the ISQ Agent card. Both on the existing "cover incoming" placeholder until the artwork lands.
- **Early 2022, eighteen months, and the jobs before code** (cricket, commercial diving, paraplanning). One anachronism fell out: the November entry credited ChatGPT with starting the learning, and ChatGPT shipped at the end of that year.
- **About prose** replaced with my own words. The old three paragraphs broke the voice rules in the first line of each.
- `//` page labels are now `_About`, `_Projects` and so on. Projects and Contact got headers to match.

## Fixes

- **Mobile close button.** `<header>` is a stacking context, and the menu's dimming backdrop is a `z-40` sibling of the bar holding the toggle, which had no `z-index` at all. The X was under a 60% black wash. `relative z-50` on the bar.
- **Dark theme readability.** The rain was never the problem. A vignette and a scanline grid sit above every word on the site and neither respected the effects toggle, which is why it was squinty with the rain off. Both softened, both now gated on `fx-off`. Cards were 94% opaque so the rain was animating through them.
- **Theme wipe** instead of a cut, via `startViewTransition`. Falls back to instant on Firefox, under reduced motion, and when effects are off.

## Testing

- `type-check`, `lint` (0 errors), 117 unit tests, and a clean build with every route over the prerender floor.
- Verified no React #418: the CRT gating is a class swap, not a conditional render, so the markup is identical on server and client.
- Lighthouse desktop on the production build: accessibility 100, best practices 100, SEO 100, CLS 0.00. Those numbers are in the new README.
- **The e2e spec is green again**, 12 passing. Six were failing: four I broke by adding a nav link and a second Leeds line, and two had been passing by accident. The updates page was checking for a milestone that has never been on that page and was matching a substring of some prose. Details in the commit.

## Not in here

- Artwork for the two new cards, and Morpheus's gallery is still of the old cloud build. Prompts for both are in `PROMPT_claude-design-assets.md`, untracked.
- `PROMPT_version-timetravel.md`, also untracked: the archive's v5 entry still sells the shelved offer.
- No performance score in the README. I measured LCP at 4.3s locally but in a headless run straight after a 56-second audit, which isn't a number worth publishing either way. Worth a proper look.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added two AI projects and expanded the featured local document Q&A case study.
  - Added animated contact-page labeling and circular theme-transition effects.
  - Effects settings now apply immediately on page load.

- **Improvements**
  - Refined dark cards, scanlines, vignette effects, tabs, mobile navigation, and responsive layouts.
  - Updated project, timeline, about, contact, and homepage content for clarity and consistency.
  - Reordered homepage proof content to highlight recent activity.

- **Bug Fixes**
  - Improved mobile header layering and theme-toggle behavior.
  - Strengthened navigation, filtering, and content checks for more reliable interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->