### PR TITLE
Wire the August artwork into the project cards

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -8,7 +8,7 @@ Contact: dev@thomasjbutler.me
 
 - [Case study](https://thomasjbutler.github.io/case-study): ISQ Agent, a RAG agent that drafts supplier security questionnaires, grounds every answer in the organisation's own policy documents with citations, scores confidence on each answer, and routes weak ones to a human. Python/FastAPI RAG engine with an n8n orchestration tier, 480+ tests. Built for a technical assessment with RiverAI and presented in person. The build ran on hosted models (Claude, Voyage, Pinecone); the model sits behind an interface, so the same pipeline runs against open models on your own hardware.
 - [Projects](https://thomasjbutler.github.io/projects): AI, web, mobile and learning projects, including Sanctuary (an offline, on-device iOS app for neurodiverse users), ModelViz (multi-provider AI model comparison), SQL Ball (natural language to SQL over football data), Morpheus (document Q&A with RAG), ReviewBot Protocol (automated PR review), and Version TimeTravel (every version of this site since 2024, all still running).
-- [Dev Journey](https://thomasjbutler.github.io/updates): a timeline of the work, from the first line of code in November 2022 to production AI systems, by way of the DWP and an agency apprenticeship.
+- [Dev Journey](https://thomasjbutler.github.io/updates): a timeline of the work, from the first line of code in early 2022 to production AI systems, by way of the DWP and an agency apprenticeship.
 
 ## About
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -7,7 +7,7 @@ Contact: dev@thomasjbutler.me
 ## Work
 
 - [Case study](https://thomasjbutler.github.io/case-study): ISQ Agent, a RAG agent that drafts supplier security questionnaires, grounds every answer in the organisation's own policy documents with citations, scores confidence on each answer, and routes weak ones to a human. Python/FastAPI RAG engine with an n8n orchestration tier, 480+ tests. Built for a technical assessment with RiverAI and presented in person. The build ran on hosted models (Claude, Voyage, Pinecone); the model sits behind an interface, so the same pipeline runs against open models on your own hardware.
-- [Projects](https://thomasjbutler.github.io/projects): AI, web, mobile and learning projects, including Sanctuary (an offline, on-device iOS app for neurodiverse users), ModelViz (multi-provider AI model comparison), SQL Ball (natural language to SQL over football data), Morpheus (document Q&A with RAG), ReviewBot Protocol (automated PR review), and Version TimeTravel (nine versions of this site, every one still running).
+- [Projects](https://thomasjbutler.github.io/projects): AI, web, mobile and learning projects, including Sanctuary (an offline, on-device iOS app for neurodiverse users), ModelViz (multi-provider AI model comparison), SQL Ball (natural language to SQL over football data), Morpheus (document Q&A with RAG), ReviewBot Protocol (automated PR review), and Version TimeTravel (every version of this site since 2024, all still running).
 - [Dev Journey](https://thomasjbutler.github.io/updates): a timeline of the work, from the first line of code in November 2022 to production AI systems, by way of the DWP and an agency apprenticeship.
 
 ## About

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -169,20 +169,71 @@ export const MEDIA = {
   },
 
   /**
-   * Screenshots of the live app rather than designed tiles, taken while Claude Design was
-   * unavailable, and picked from thirteen.
+   * Designed tiles, August 2026. These replace padded screenshots of the live app that stood in
+   * while Claude Design was unavailable; the cover is a 1600x750 tile, so this is now in
+   * DESIGNED_COVERS.
    *
-   * They arrived at 2880x1800, which is 1.600 and not the gallery's 16:9. Padded to 3200x1800
-   * in #0D0D0D rather than cropped: the app's own chrome samples at exactly that value, so the
-   * bars are invisible, and a 10% centre-crop would have taken the header off the top of all
-   * four. Nothing is lost and nothing is stretched.
+   * The gallery is stamped 01, 02, 03, 05. There is no 04 in the delivered set and the gap is
+   * accepted rather than a missing upload.
+   *
+   * Tile 01 embeds a capture of the live archive reading "9 versions - 25 months". The archive
+   * derives that from its own data and now says 26, because the August entry moved the last
+   * date. It is left as taken: it is a screenshot of a real moment, and this project of all of
+   * them is about showing what a thing actually looked like. The cover's stat is *designed*
+   * rather than captured, so that one was re-cut to 26.
    */
   'version-timetravel': {
+    cover: img(T.cover, 'v1787888996', 'hgy24rsfvo31dszokljo'),
     gallery: [
-      img(T.gallery, 'v1785173002', 'l3jzdt9ibolklfpl8wnp'),
-      img(T.gallery, 'v1785173003', 'nfnw74zg2wkqznfzvfg2'),
-      img(T.gallery, 'v1785173003', 'yrosd6uwwiqyrprkjiqn'),
-      img(T.gallery, 'v1785173003', 'wysieimgciy3n9xyn4jc'),
+      img(T.gallery, 'v1787888994', 'aj0ffj7mgt49yonwqf0q'),
+      img(T.gallery, 'v1787888995', 'y5hsatkiv4vrj38jlemm'),
+      img(T.gallery, 'v1787888997', 'nksysetwsccguc1xzxo0'),
+      img(T.gallery, 'v1787888995', 'oduxlsrmpiolxk5nzjpv'),
+    ],
+  },
+
+  /**
+   * Added August 2026 alongside the cards themselves. All three covers are designed 1600x750
+   * tiles, so all three belong in DESIGNED_COVERS.
+   *
+   * Octopus is the one set that is not Matrix green. It carries the product's own light
+   * palette, which is what the palette rule allows for a product's own artwork.
+   *
+   * Offshore's tiles are styled as a technical report and carry its section numbers. The
+   * gallery opens on the linkage pipeline (2.1) and then runs 3.2, 4.1, so it reads in the
+   * report's own order; the delivered order put 2.1 last, where the method arrived after its
+   * own results. The publication gate, 2.4, is the diagram.
+   */
+  'octopus-job-hunter': {
+    cover: img(T.cover, 'v1787888988', 'mg1swlik9lt8a5kscmp6'),
+    gallery: [
+      img(T.gallery, 'v1787888989', 'i5rexfswuqovoywyguu1'),
+      img(T.gallery, 'v1787888990', 'pbu07eju1nsniuomtrvs'),
+      img(T.gallery, 'v1787888984', 'o6qbmwnpzudc94odujop'),
+      img(T.gallery, 'v1787888990', 'yazfvg3pavxmwppidchw'),
+    ],
+    diagram: img(T.gallery, 'v1787888988', 'vkwpetfcv89bmkulf7pj'),
+    wireframe: img(T.gallery, 'v1787888990', 'dxqd4jrh4kvxm9h4jabi'),
+  },
+
+  'offshore-property-map': {
+    cover: img(T.cover, 'v1787888991', 'ycfv7dfek2olzanoa2fv'),
+    gallery: [
+      img(T.gallery, 'v1787888985', 'r4rmi8yirnwcmg630vde'),
+      img(T.gallery, 'v1787888990', 'rom8trvj65cwzrzxkwlj'),
+      img(T.gallery, 'v1787888991', 'o9552vkqunmrum1qnxk8'),
+    ],
+    diagram: img(T.gallery, 'v1787888985', 'rpcwn1essosncseuwrre'),
+  },
+
+  'premier-league-oracle': {
+    cover: img(T.cover, 'v1787888994', 'luuiw3yotyctpe1qhs4x'),
+    gallery: [
+      img(T.gallery, 'v1787888992', 'ymejzjt3feu67gbbkooc'),
+      img(T.gallery, 'v1787888992', 'z230siasp2ezsdjrssuw'),
+      img(T.gallery, 'v1787888993', 'u3mutjaflpe8pei6riqb'),
+      img(T.gallery, 'v1787888993', 'jcxetopzxbwl9f2h4kuz'),
+      img(T.gallery, 'v1787888993', 'oyko4qjsm7vv2wqfo285'),
     ],
   },
 
@@ -313,6 +364,10 @@ const DESIGNED_COVERS = new Set([
   'modelviz',
   'reviewbot-protocol',
   'news-perspective',
+  'version-timetravel',
+  'octopus-job-hunter',
+  'offshore-property-map',
+  'premier-league-oracle',
 ]);
 
 export function hasDesignedCover(id: string): boolean {

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -103,19 +103,31 @@ export const MEDIA = {
     hero: img(T.hero, 'v1785172983', 'yo2ngxidzrutqxjgqcmc'),
   },
 
+  /**
+   * Recut August 2026 for the local rebuild. The old set showed the hosted build this project
+   * started as, down to a "[LLM] CLAUDE / [NET] ONLINE" status bar; the new one runs on Ollama
+   * and LanceDB and says so.
+   *
+   * `diagram` and `wireframe` are the same artwork as gallery 04 and 05, at native 1640 rather
+   * than letterboxed into the gallery's 16:9. So each appears twice in the modal, once in the
+   * strip and once captioned under "Under the hood". That is deliberate, not an oversight.
+   *
+   * `poster` is unchanged: the loop was recut but no new poster frame was made, and the old one
+   * still matches the first frame closely enough to stand in behind it.
+   */
   morpheus: {
-    cover: img(T.cover, 'v1785172990', 'pggcvdmmjl3cbr2fuxxm'),
+    cover: img(T.cover, 'v1787888988', 'dtmtetjvdaoc4uih3ekk'),
     gallery: [
-      img(T.gallery, 'v1785172988', 'wvjfefgetbabeave4fdl'),
-      img(T.gallery, 'v1785172989', 'uwnlrlrrn83uwtb83hr5'),
-      img(T.gallery, 'v1785172989', 'pcnhzeqw2qozxjqfuseu'),
-      img(T.gallery, 'v1785172989', 'x6piqlqx5qy1bonncbdx'),
-      img(T.gallery, 'v1785172989', 'jlgsjfvpac4cutxxpsyr'),
+      img(T.gallery, 'v1787888985', 'zrmofu85isz1qkkstdwz'),
+      img(T.gallery, 'v1787888986', 'yti3oa6f8sci74a2xdqj'),
+      img(T.gallery, 'v1787891756', 'kvnbz2bcigtmipgbp9ah'),
+      img(T.gallery, 'v1787888986', 'trl2vnksukogqx3jrfa1'),
+      img(T.gallery, 'v1787888986', 'opyqf74ubbxzhnmhvbfs'),
     ],
-    loop: img(T.loop, 'v1785172990', 'rmcre0s8ayjuqgctfphh', 'mp4'),
+    loop: img(T.loop, 'v1787888987', 'axsby0k2p3sn4av8r1cx', 'mp4'),
     poster: img(T.poster, 'v1785172989', 'k3yxjuxcszqbxjwxtso1', 'jpg'),
-    diagram: img(T.gallery, 'v1785172980', 'zlyszkv8fqohzbxr5gc4'),
-    wireframe: img(T.gallery, 'v1785173004', 'rbbdvc1l3rvhmke5frc6'),
+    diagram: img(T.gallery, 'v1787891796', 'tmyanitzhebg7bvueesn'),
+    wireframe: img(T.gallery, 'v1787888996', 'dutngyhiquned8qu0lzj'),
   },
 
   modelviz: {

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -198,7 +198,10 @@ export const projects: Project[] = [
     // No status. The build is live and the demo still works, so the links stay, but it is
     // not being actively developed and "Completed" over a cover badged NOW DISCONTINUED
     // was the card and the artwork disagreeing in the same modal.
-
+    images: {
+      cover: MEDIA['premier-league-oracle'].cover,
+      gallery: MEDIA['premier-league-oracle'].gallery,
+    },
     highlights: [
       'The Butler model, fitted over 33 seasons',
       'RPS 0.2000 vs the bookmaker ceiling of 0.1939',
@@ -252,6 +255,17 @@ export const projects: Project[] = [
     // address-use and deletion duties that a public demo could not honour.
     links: {},
     status: 'in-progress',
+    images: {
+      cover: MEDIA['offshore-property-map'].cover,
+      gallery: MEDIA['offshore-property-map'].gallery,
+    },
+    underTheHood: {
+      diagram: {
+        src: MEDIA['offshore-property-map'].diagram,
+        caption:
+          'The publication gate, drawn. What clears the bar is not the estimate but the lower bound of its 95% interval: 0.9950 measured, 0.9765 at the bound, against a threshold of 0.95. Shrink the audit sample and that same estimate fails, which is the whole reason the gate reads the bound and not the number.',
+      },
+    },
     highlights: [
       'Two public registers, no shared key, real consequences for a wrong match',
       'Probabilistic matching with Splink, over DuckDB',
@@ -270,6 +284,22 @@ export const projects: Project[] = [
     // Private: it holds a real profile and a real application history.
     links: {},
     status: 'completed',
+    images: {
+      cover: MEDIA['octopus-job-hunter'].cover,
+      gallery: MEDIA['octopus-job-hunter'].gallery,
+    },
+    underTheHood: {
+      diagram: {
+        src: MEDIA['octopus-job-hunter'].diagram,
+        caption:
+          'Your own files on the left, five markdown playbooks in the middle, four CV formats and a tracker on the right. The playbooks are the product rather than the code: Claude, Codex or a model running on your own machine can each follow them, so an employment history never has to leave the laptop to be useful.',
+      },
+      wireframe: {
+        src: MEDIA['octopus-job-hunter'].wireframe,
+        caption:
+          'One screen. Boards down the left, the advert and how well it matches in the middle, the tailored CV building on the right. Generate, save to the tracker, open the advert. There is no button that applies for you, and that is deliberate.',
+      },
+    },
     highlights: [
       'Sixteen specialist boards through official feeds, in about ten seconds',
       'One CV library, four output formats per role',
@@ -627,7 +657,7 @@ export const projects: Project[] = [
     category: 'portfolio',
     links: { demo: 'https://thomasjbutler.github.io/version-timetravel/', github: 'https://github.com/ThomasJButler/version-timetravel' },
     images: {
-      cover: 'https://res.cloudinary.com/depqttzlt/image/upload/f_auto,q_auto,w_800/v1767710995/portfoliotimetravel_rh7jgr.png',
+      cover: MEDIA['version-timetravel'].cover,
       gallery: MEDIA['version-timetravel'].gallery,
     },
     highlights: [

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -195,13 +195,14 @@ export const projects: Project[] = [
       demo: 'https://the-premier-league-oracle.vercel.app',
       github: 'https://github.com/ThomasJButler/The-Premier-League-Oracle',
     },
-    // No status. The build is live and the demo still works, so the links stay, but it is
-    // not being actively developed and "Completed" over a cover badged NOW DISCONTINUED
-    // was the card and the artwork disagreeing in the same modal.
     images: {
       cover: MEDIA['premier-league-oracle'].cover,
       gallery: MEDIA['premier-league-oracle'].gallery,
     },
+    // There is deliberately no `status` on this one. The build is live and the demo still
+    // works, so the links stay, but it is not being actively developed, and "Completed"
+    // over a cover badged NOW DISCONTINUED was the card and the artwork disagreeing in
+    // the same modal.
     highlights: [
       'The Butler model, fitted over 33 seasons',
       'RPS 0.2000 vs the bookmaker ceiling of 0.1939',
@@ -405,7 +406,7 @@ export const projects: Project[] = [
       wireframe: {
         src: MEDIA.morpheus.wireframe,
         caption:
-          'Three columns: the documents you have indexed on the left, the thread in the middle, library size and the last answer\'s timings on the right. The one amber state is an answer that cited nothing, and it keeps its place in the thread rather than being quietly dropped.',
+          'Three columns: the documents you have indexed on the left, the thread in the middle, library size and the last answer’s timings on the right. The one amber state is an answer that cited nothing, and it keeps its place in the thread rather than being quietly dropped.',
       },
     },
     videos: ['https://res.cloudinary.com/depqttzlt/video/upload/vc_auto,q_auto,w_960/v1767706547/2_1080_N_s5t1ww.mp4'],
@@ -642,13 +643,14 @@ export const projects: Project[] = [
     name: 'Version TimeTravel',
     description: 'A working archive of every version of this site since 2024. Every one still runs, in the browser, as it originally shipped.',
     /*
-     * "9 portfolio versions" kept, and it is the app's own figure: its hero and its stat line
-     * both say nine, and the chronology rail lists nine. `versions.ts` holds ten entries and
-     * the thumbnail strip shows ten, because the commercial site is in the archive without
-     * being a version of this portfolio. Consistent, but worth a glance during the QA pass.
+     * No version count in the copy, on purpose. `versions.ts` holds eleven entries, one of
+     * which is withheld, so ten are visible; nine of those ten are this portfolio's own
+     * lineage, because the commercial site sits in the archive without being a version of
+     * this site. Any number typed here drifts the moment an entry is added or hidden, and it
+     * already did: the card claimed nine while the archive was showing something else.
      *
      * `language` left as JavaScript deliberately. The app's own source is TypeScript, but
-     * GitHub's breakdown for the repo is CSS, HTML and JavaScript, because ten archived static
+     * GitHub's breakdown for the repo is CSS, HTML and JavaScript, because the archived static
      * sites dwarf the viewer that displays them. The field is a coloured dot, and deferring to
      * GitHub is the rule the other entries follow.
      */

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -195,7 +195,10 @@ export const projects: Project[] = [
       demo: 'https://the-premier-league-oracle.vercel.app',
       github: 'https://github.com/ThomasJButler/The-Premier-League-Oracle',
     },
-    status: 'completed',
+    // No status. The build is live and the demo still works, so the links stay, but it is
+    // not being actively developed and "Completed" over a cover badged NOW DISCONTINUED
+    // was the card and the artwork disagreeing in the same modal.
+
     highlights: [
       'The Butler model, fitted over 33 seasons',
       'RPS 0.2000 vs the bookmaker ceiling of 0.1939',

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -605,7 +605,7 @@ export const projects: Project[] = [
   {
     id: 'version-timetravel',
     name: 'Version TimeTravel',
-    description: 'A working archive of nine portfolio versions. Every one still runs, in the browser, as it originally shipped.',
+    description: 'A working archive of every version of this site since 2024. Every one still runs, in the browser, as it originally shipped.',
     /*
      * "9 portfolio versions" kept, and it is the app's own figure: its hero and its stat line
      * both say nine, and the chronology rail lists nine. `versions.ts` holds ten entries and
@@ -618,7 +618,7 @@ export const projects: Project[] = [
      * GitHub is the rule the other entries follow.
      */
     longDescription:
-      'Nine versions of one portfolio, from hand-written HTML in June 2024 to React and shadcn today, and every one of them still runs. Pick any version and the original build loads in a viewer you can resize to 1440, 834 or 390 to see how it behaved on a phone at the time. The builds are unmodified, so some of them reference assets that no longer exist, and the archive says so rather than quietly patching them. It is the clearest record of how fast the work moved: the same person, twenty-five months apart.',
+      'Every version of this site since June 2024, from hand-written HTML to React and shadcn today, and every one of them still runs. Pick any version and the original build loads in a viewer you can resize to 1440, 834 or 390 to see how it behaved on a phone at the time. The builds are unmodified, so some of them reference assets that no longer exist, and the archive says so rather than quietly patching them. It is the clearest record of how fast the work moved: the same person, two years apart.',
     topics: ['Timeline', 'Interactive', 'Archive'],
     language: 'JavaScript',
     category: 'portfolio',
@@ -628,10 +628,10 @@ export const projects: Project[] = [
       gallery: MEDIA['version-timetravel'].gallery,
     },
     highlights: [
-      'Nine versions, every one still runnable',
+      'Every version still runnable, none of them patched',
       'Original builds, unmodified, flagged where assets are gone',
       'Resizable viewer: 1440, 834 and 390',
-      'Twenty-five months, one person',
+      'Two years of it, one person',
     ],
   },
   {

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -383,7 +383,8 @@ export const projects: Project[] = [
     category: 'ai',
     links: { demo: 'https://morpheusrag.vercel.app', github: 'https://github.com/ThomasJButler/Morpheus' },
     // The gallery used to be a single 8.8MB GIF (morpheusgif2_zdkku9.gif). Five stills and a
-    // 72kB loop say more and cost 2% of the bytes.
+    // loop say more and cost a fraction of the bytes. Recut in August 2026 for the local
+    // rebuild; gallery 04 and 05 are the diagram and wireframe letterboxed into 16:9.
     images: {
       cover: MEDIA.morpheus.cover,
       gallery: MEDIA.morpheus.gallery,
@@ -396,14 +397,15 @@ export const projects: Project[] = [
       },
       diagram: {
         src: MEDIA.morpheus.diagram,
-        // The diagram still shows the hosted build this project started as. The green
-        // generation step it described as "moving to Ollama" has now moved, along with
-        // the vector store; the artwork is the last thing left to redraw.
+        // Redrawn August 2026. The old one showed the hosted build this project started as,
+        // with a generation step captioned "moving to Ollama"; it has moved, and so has the
+        // vector store, and the artwork now names LanceDB and Ollama on :11434.
         caption: 'Your documents, an index that lives on your own disk, and an answer that cites where it came from. Every step of this runs on the machine in front of you.',
       },
       wireframe: {
         src: MEDIA.morpheus.wireframe,
-        caption: 'Ask on the left, the answer and its sources on the right. Every claim traceable back to a page.',
+        caption:
+          'Three columns: the documents you have indexed on the left, the thread in the middle, library size and the last answer\'s timings on the right. The one amber state is an answer that cited nothing, and it keeps its place in the thread rather than being quietly dropped.',
       },
     },
     videos: ['https://res.cloudinary.com/depqttzlt/video/upload/vc_auto,q_auto,w_960/v1767706547/2_1080_N_s5t1ww.mp4'],


### PR DESCRIPTION
## What

Designed covers and galleries for five project cards: Morpheus,
OctopusJobHunter, Offshore Property Map, The Premier League Oracle and
Version TimeTravel. Octopus, Offshore and Morpheus also get their
"Under the hood" figures.

Two smaller fixes already on the branch: the TimeTravel card counted
archive versions it can no longer see, and the Oracle carried a
Completed badge over a cover badged NOW DISCONTINUED.

## Why

Every CV links here and the reader is a hiring manager. Four of the
twenty cards had no artwork at all, so some of the strongest projects
on the site were the plainest things on the page.

Morpheus had artwork, but the wrong artwork: it was shot against the
hosted build the project started as, down to a "[LLM] CLAUDE / [NET]
ONLINE" status bar, while the card beside it argued for running the
model on your own machine.

## How

The upload sheet could not be trusted. Cloudinary hands back a random
public id per upload, so the URLs came back in a different order than
they went out and 19 of the 32 rows named the wrong file. Octopus, for
one, had its architecture diagram in the gallery and a gallery shot
under "Under the hood".

Every asset was downloaded and matched back to its local file by md5,
and the sheet was rewritten from that. Worth a reviewer's attention:
none of these pairings are eyeballed, and the same check was run again
on the last two files after they were uploaded.

Offshore's tiles are styled as a technical report and carry its section
numbers. The delivered order ran 3.2, 4.1, 2.1, so the method arrived
after its own results. It now opens on the pipeline and runs 2.1, 3.2,
4.1, with the publication gate (2.4) as the diagram.

All five covers are 1600x750, so all five are in DESIGNED_COVERS.

## Testing

- `npm run type-check` clean, `npm run lint` 0 errors
- 117 unit and component tests pass
- `npm run build` clean, every route over the 600-char prerender floor
- All 32 assets verified by md5 against the file they claim to be
- All transformed Cloudinary URLs return 200, including the Morpheus
  loop as video/mp4 (1.39MB GIF in, 97kB mp4 out)
- `/projects` rendered in Chrome: 26 images, 0 broken, 0 console errors
- Offshore and Morpheus modals opened in the browser and checked image
  by image for order

## Known and accepted

Morpheus gallery 04 and 05 are the diagram and wireframe letterboxed to
16:9, and the same two also sit under "Under the hood" at native 1640,
so each appears twice in the modal. Deliberate.

Version TimeTravel's gallery tile 01 embeds a screenshot of the live
archive reading "25 months". The archive computes that from its own
data and now says 26, because the August entry moved the last date. The
tile is a capture of a real moment so it stays as taken. The cover's
stat is designed rather than captured, so that one was re-cut to 26.

The Oracle's gallery tiles 04 and 05 still say the model won money on
casual bets. Left in on purpose; the cover's claim and its WON REAL
BETS badge were the ones that came off.

The Octopus tiles run on sample data, not on a real profile: the
employer is Northwind Systems, which is Microsoft's sample database, and
the advert, interview slot and certificate are all invented to match. The
"Nothing here is invented" line on that tile is the product's promise
about your own file, not a claim that the screenshot is a real history.
Flagged in review and confirmed as sample data, so noting it here rather
than leaving it to be found again.
